### PR TITLE
Use Boto3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,14 @@ Generate a report of all s3 buckets and their permissions
 Usage
 =====
 
-    python s3scan.py [-k <api_key>] [-s <api_secret>] [-f <format>]
+    python s3scan.py [-f <format>]
 
     Options:
 
-        -k | --key     S3 Access Key
-        -s | --secret  S3 Access Secret
         -f | --format  Output format
                        [Optional]
 
 Where the output format can be either 'text' or 'csv'
-
-If no parameters are given, the configuration file 's3scan.cfg' will
-be loaded and should contain:
-
-    [aws]
-    access_key = YOUR_KEY_HERE
-    access_secret = YOUR_SECRETS_HERE
-    format = text
 
 Requirements
 ============
@@ -31,5 +21,5 @@ Requirements
 Python 2.6+ 
 http://python.org
 
-Boto Library
-https://github.com/boto/boto
+Boto3 Library
+https://github.com/boto/boto3

--- a/s3scan.py
+++ b/s3scan.py
@@ -4,7 +4,7 @@
 
 Usage:
 
-  python s3scan.py [-k <api_key>] [-s <api_secret>] [-f <format>]
+  python s3scan.py [-f <format>]
 
 Options:
 

--- a/s3scan.py
+++ b/s3scan.py
@@ -8,28 +8,17 @@ Usage:
 
 Options:
 
-  -k | --key     S3 Access Key
-  -s | --secret  S3 Access Secret
   -f | --format  Output format
                  [Optional]
 
   Where the output format can be either 'text' or 'csv'
-
-If no parameters are given, the configuration file 's3scan.cfg' will
-be loaded and should contain:
-
-    [aws]
-    access_key = YOUR_KEY_HERE
-    access_secret = YOUR_SECRETS_HERE
-    format = text
-
 """
 
-VERSION = (0, 1, 1, '')
+VERSION = (0, 1, 2, '')
 
 __author__    = 'bear (Mike Taylor)'
 __contact__   = 'bear@bear.im'
-__copyright__ = 'Copyright 2012-2015, Mike Taylor'
+__copyright__ = 'Copyright 2012-2016, Mike Taylor'
 __license__   = 'BSD 2-Clause'
 __site__      = 'https://github.com/bear/s3scan'
 __version__   = u'.'.join(map(str, VERSION[0:3])) + u''.join(VERSION[3:])
@@ -37,78 +26,50 @@ __version__   = u'.'.join(map(str, VERSION[0:3])) + u''.join(VERSION[3:])
 
 import os
 import ConfigParser
+import boto3
 
 from optparse import OptionParser
-from xml.etree import cElementTree as ET
-
-from boto.s3.connection import S3Connection, OrdinaryCallingFormat
-
 
 def getConfig():
     parser = OptionParser()
-
-    parser.add_option('-k', '--key',    dest='api_key',    default='',     help='S3 Access Key')
-    parser.add_option('-s', '--secret', dest='api_secret', default='',     help='S3 Access Secret')
+    # Read API Key & Secret from Environment...
     parser.add_option('-f', '--format', dest='format',     default='text', help='Output format: text, csv')
-
     options, args = parser.parse_args()
 
-    api_key    = options.api_key
-    api_secret = options.api_secret
-    format     = options.format
+    format = options.format
+    return format
 
-    if os.path.isfile('s3scan.cfg'):
-        config = ConfigParser.SafeConfigParser({ 'access_key':    api_key,
-                                                 'access_secret': api_secret,
-                                                 'format':        format,
-                                               })
-        config.read('s3scan.cfg')
-
-        api_key    = config.get('aws', 'access_key')
-        api_secret = config.get('aws', 'access_secret')
-        format     = config.get('aws', 'format').lower()
-
-    return (api_key, api_secret, format)
-
-
-def discoverBuckets(api_key, api_secret):
-    c  = S3Connection(api_key, api_secret, calling_format=OrdinaryCallingFormat())
-    rs = c.get_all_buckets()
+def discoverBuckets():
+    s3  = boto3.resource('s3')
+    rs = s3.buckets.all()
 
     buckets = {}
-    maxName = 0
+    maxName = 0 #use pprint instead?
 
     for b in rs:
         bucketName          = b.name
         buckets[bucketName] = {}
 
+        #keep track of longest bucketName for textFormat
         if len(bucketName) > maxName:
             maxName = len(bucketName)
 
-        acp = b.get_acl()
-        xml = acp.acl.to_xml()
+        for grant in b.Acl().grants:
+            grantee_name = 'None'
+            grantee_id = 'None'
 
-        xRoot = ET.fromstring(xml)
-        for grant in xRoot:
-            grantee = { 'id': None, 'name': None, 'permission': [] }
+            grantee = grant['Grantee']
+            if 'DisplayName' in grantee:
+                grantee_name = grantee['DisplayName']
+                grantee_id = grantee['ID']
+            elif 'URI' in grantee:
+                grantee_name = grantee['URI'].split('/')[-1]
+                grantee_id = grantee['URI']
 
-            for item in grant:
-                if item.tag == 'Grantee':
-                    for element in item:
-                        if element.tag == 'ID':
-                            grantee['id'] = element.text
-                        elif element.tag == 'DisplayName':
-                            grantee['name'] = element.text
-                        elif element.tag == 'URI':
-                            grantee['id']   = element.text
-                            grantee['name'] = element.text.split('/')[-1]
-                elif item.tag == 'Permission':
-                    grantee['permission'].append(item.text)
+            if grantee_name not in buckets[bucketName]:
+                buckets[bucketName][grantee_name] = []
 
-            if grantee['name'] not in buckets[bucketName]:
-                buckets[bucketName][grantee['name']] = []
-
-            buckets[bucketName][grantee['name']].append((grantee['id'], grantee['permission']))
+            buckets[bucketName][grantee_name].append((grantee_id,grant['Permission']))
 
     return buckets, maxName
 
@@ -120,14 +81,19 @@ def csvFormat(bucket):
 
     for grantee in bucket:
         for grantee_id, permission in bucket[grantee]:
-            if 'READ' in permission:
+            if 'READ' == permission:
                 reads.append(grantee)
-            if 'WRITE' in permission:
+            if 'WRITE' == permission:
                 writes.append(grantee)
-            if 'READ_ACP' in permission:
+            if 'READ_ACP' ==  permission:
                 reads_acp.append(grantee)
-            if 'WRITE_ACP' in permission:
+            if 'WRITE_ACP' == permission:
                 writes_acp.append(grantee)
+            if 'FULL_CONTROL' == permission:
+                reads.append(grantee)
+                writes.append(grantee)
+                writes_acp.append(grantee)
+                reads_acp.append(grantee)
 
     l = [key,
          ';'.join(writes),
@@ -138,22 +104,28 @@ def csvFormat(bucket):
 
     return ','.join(l)
 
-
 def textFormat(bucket, maxName):
     reads      = []
     writes     = []
     reads_acp  = []
     writes_acp = []
 
+    # Adding full_control
+    # see: http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions
     for grantee in bucket:
         for grantee_id, permission in bucket[grantee]:
-            if 'READ' in permission:
+            if 'READ' == permission:
                 reads.append(grantee)
-            if 'WRITE' in permission:
+            if 'WRITE' == permission:
                 writes.append(grantee)
-            if 'READ_ACP' in permission:
+            if 'READ_ACP' == permission:
                 reads_acp.append(grantee)
-            if 'WRITE_ACP' in permission:
+            if 'WRITE_ACP' == permission:
+                writes_acp.append(grantee)
+            if 'FULL_CONTROL' == permission:
+                reads.append(grantee)
+                writes.append(grantee)
+                reads_acp.append(grantee)
                 writes_acp.append(grantee)
 
     s = '{0:>{1}} --'.format(key, maxName)
@@ -170,9 +142,9 @@ def textFormat(bucket, maxName):
     return s
 
 if __name__ == '__main__':
-    api_key, api_secret, format = getConfig()
+    format = getConfig()
 
-    buckets, maxName = discoverBuckets(api_key, api_secret)
+    buckets, maxName = discoverBuckets()
 
     for key in buckets:
         bucket = buckets[key]


### PR DESCRIPTION
Updated to use Boto3.. However - I removed the API key & Secret parameters as I pass these in via the environment. Also added support for `full_control` and fixed a bug where `READ is in READ_ACP` causing grantees to be listed twice.